### PR TITLE
Add scaffolding to push to PyPI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
-SHELL := /bin/bash
+SHELL := /bin/bash 
 VERSION = $(shell sed 's/^__version__ = "\(.*\)"/\1/' ./tempo/version.py)
-IMAGE=mlops
 
 .PHONY: install
 install:
@@ -54,6 +53,19 @@ tempo/tests/examples/sklearn:
 
 clean_test_data:
 	rm -rf tempo/tests/examples
+
+
+build: clean
+	python setup.py sdist bdist_wheel
+
+clean:
+	rm -rf ./dist ./build *.egg-info
+
+push-test:
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+push:
+	twine upload dist/*
 
 
 version:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SHELL := /bin/bash
-VERSION := 0.1
+VERSION = $(shell sed 's/^__version__ = "\(.*\)"/\1/' ./tempo/version.py)
 IMAGE=mlops
 
 .PHONY: install
@@ -56,3 +56,5 @@ clean_test_data:
 	rm -rf tempo/tests/examples
 
 
+version:
+	@echo ${VERSION}

--- a/hack/update-version.sh
+++ b/hack/update-version.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+ROOT_FOLDER="$(dirname "${0}")/.."
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: ./update-version.sh <newVersion>"
+  exit 1
+fi
+
+_updateVersion() {
+  local _newVersion=$1
+  local _versionPy=$2
+
+  sed -i "s/^__version__ = \"\(.*\)\"$/__version__ = \"$_newVersion\"/" "$_versionPy"
+}
+
+_main() {
+  local _newVersion=$1
+
+  # To call within `-exec`
+  export -f _updateVersion
+
+  find $ROOT_FOLDER \
+    -type f -name version.py \
+    -path "$ROOT_FOLDER/tempo/*" \
+    -exec bash -c "_updateVersion $_newVersion {}" \;
+}
+
+_main $1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,16 @@
-# Test and linters
+# Code generation
+grpcio-tools==1.35.0
+
+# Linting and formatting
 black==19.10b0
 flake8==3.8.1
 mypy<0.783
-Pillow==7.2.0
+mypy-protobuf==1.22
+
+# Testing
 pytest==5.4.2
 pytest-cov==2.10.1
 pytest-asyncio==0.14.0
-tox<4.0.0
-grpcio-tools==1.31.0
-mypy-protobuf==1.22
 
+# Pushing to PyPi
+twine==3.3.0

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ def _load_description() -> str:
 
 
 setup(
-    name=PKG_NAME,
+    #  name=PKG_NAME,
+    # TODO: Update once we've got consensus on package name
+    name="mlops-tempo",
     author="Seldon Technologies Ltd.",
     author_email="hello@seldon.io",
     version=_load_version(),

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,38 @@
+import os
+
+from typing import Dict
 from setuptools import find_packages, setup
-from tempo import __version__
 
 
-def readme():
-    with open("README.md") as f:
-        return f.read()
+ROOT_PATH = os.path.dirname(__file__)
+PKG_NAME = "tempo"
+PKG_PATH = os.path.join(ROOT_PATH, PKG_NAME)
 
 
-# read version file
-exec(open("tempo/version.py").read())
+def _load_version() -> str:
+    version = ""
+    version_path = os.path.join(PKG_PATH, "version.py")
+    with open(version_path) as fp:
+        version_module: Dict[str, str] = {}
+        exec(fp.read(), version_module)
+        version = version_module["__version__"]
+
+    return version
+
+
+def _load_description() -> str:
+    readme_path = os.path.join(ROOT_PATH, "README.md")
+    with open(readme_path) as fp:
+        return fp.read()
 
 
 setup(
-    name="tempo",
+    name=PKG_NAME,
     author="Seldon Technologies Ltd.",
     author_email="hello@seldon.io",
-    version=__version__,  # type: ignore # noqa F821
+    version=_load_version(),
     description="Machine Learning Operations Toolkit",
-    long_description=readme(),
-    long_description_content_type="text/markdown",
     url="https://github.com/SeldonIO/tempo",
-    license="Apache 2.0",
     packages=find_packages(),
     include_package_data=True,
     python_requires=">=3.6",
@@ -37,4 +49,7 @@ setup(
     ],
     tests_require=["pytest", "pytest-cov", "pytest-xdist", "pytest-lazy-fixture"],
     zip_safe=False,
+    long_description=_load_description(),
+    long_description_content_type="text/markdown",
+    license="Apache 2.0",
 )

--- a/tempo/version.py
+++ b/tempo/version.py
@@ -1,5 +1,1 @@
-# Store the version here so:
-# 1) we don't load dependencies by storing it in __init__.py
-# 2) we can import it in setup.py for the same reason
-# 3) we can import it into your module module
-__version__ = "0.1.0"
+__version__ = "0.1.0.dev0"


### PR DESCRIPTION
## Changelog

- Add some scaffolding to push package to PyPI
- Rename package name to `mlops-tempo` (the actual module is still called `tempo`). 