### PR TITLE
Optionally load config for seldon deploy from the config file

### DIFF
--- a/docs/examples/deploy/README.md
+++ b/docs/examples/deploy/README.md
@@ -6,6 +6,8 @@ import os
 import pprint
 import numpy as np
 
+# You can not specify host, user, and password to use values from the Seldon Deploy config file located at
+# ~/.config/seldon/seldon-deploy/sdconfig.txt
 rt = SeldonDeployRuntime(host="http://34.105.136.157/seldon-deploy/api/v1alpha1",
                         user="admin@kubeflow.org",
                         password= "12341234",


### PR DESCRIPTION
We use a config file located at `~/.config/seldon/seldon-deploy/sdconfig.txt` for configuring different things in seldon deploy including the host, username, password. We can use this to create the SD runtime which helps us avoid sharing credentials in github when sharing notebooks.

I tested this change by removing the username/pass from the example deploy notebook and it works fine with my `sdconfig` file.

ps. my python is quite rusty, please shout if something can be done better