### PR TITLE
use link to .html instead of .md

### DIFF
--- a/docs/examples/custom-model/README.ipynb
+++ b/docs/examples/custom-model/README.ipynb
@@ -355,7 +355,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/custom-model/README.ipynb
+++ b/docs/examples/custom-model/README.ipynb
@@ -355,7 +355,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/custom-model/README.md
+++ b/docs/examples/custom-model/README.md
@@ -245,7 +245,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/custom-model/README.md
+++ b/docs/examples/custom-model/README.md
@@ -245,7 +245,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/explainer/README.ipynb
+++ b/docs/examples/explainer/README.ipynb
@@ -310,7 +310,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/explainer/README.ipynb
+++ b/docs/examples/explainer/README.ipynb
@@ -310,7 +310,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/explainer/README.md
+++ b/docs/examples/explainer/README.md
@@ -193,7 +193,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/explainer/README.md
+++ b/docs/examples/explainer/README.md
@@ -193,7 +193,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/kfserving/README.ipynb
+++ b/docs/examples/kfserving/README.ipynb
@@ -357,7 +357,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-kfserving)."
+    "Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-kfserving)."
    ]
   },
   {

--- a/docs/examples/kfserving/README.ipynb
+++ b/docs/examples/kfserving/README.ipynb
@@ -357,7 +357,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-kfserving)."
+    "Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-kfserving)."
    ]
   },
   {

--- a/docs/examples/kfserving/README.md
+++ b/docs/examples/kfserving/README.md
@@ -227,7 +227,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-kfserving).
+Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-kfserving).
 
 
 ```python

--- a/docs/examples/kfserving/README.md
+++ b/docs/examples/kfserving/README.md
@@ -227,7 +227,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-kfserving).
+Create a Kind Kubernetes cluster with Minio and KFserving installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-kfserving).
 
 
 ```python

--- a/docs/examples/multi-model/README.ipynb
+++ b/docs/examples/multi-model/README.ipynb
@@ -347,7 +347,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/multi-model/README.ipynb
+++ b/docs/examples/multi-model/README.ipynb
@@ -347,7 +347,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/multi-model/README.md
+++ b/docs/examples/multi-model/README.md
@@ -218,7 +218,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/multi-model/README.md
+++ b/docs/examples/multi-model/README.md
@@ -218,7 +218,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/outlier/README.ipynb
+++ b/docs/examples/outlier/README.ipynb
@@ -419,7 +419,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/outlier/README.ipynb
+++ b/docs/examples/outlier/README.ipynb
@@ -419,7 +419,7 @@
     " \n",
     "### Prerequisites\n",
     " \n",
-    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
+    "Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core)."
    ]
   },
   {

--- a/docs/examples/outlier/README.md
+++ b/docs/examples/outlier/README.md
@@ -266,7 +266,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](https://tempo.readthedocs.io/en/latest/overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python

--- a/docs/examples/outlier/README.md
+++ b/docs/examples/outlier/README.md
@@ -266,7 +266,7 @@ remote_model.undeploy()
  
 ### Prerequisites
  
-Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.md#kubernetes-cluster-with-seldon-core).
+Create a Kind Kubernetes cluster with Minio and Seldon Core installed using Ansible as described [here](../../overview/quickstart.html#kubernetes-cluster-with-seldon-core).
 
 
 ```python


### PR DESCRIPTION
Changing relative link to point at `.html` and not `.md` file. 

Same way it is done [here](https://github.com/SeldonIO/tempo/blob/master/docs/overview/architecture.md). 

Alternative would to have non-relative link to https://tempo.readthedocs.io/en/latest/overview/quickstart.html but I am not convinced this is best idea. Can change if that would be better.