### PR TITLE
Default to no executor for seldon core runtime

### DIFF
--- a/ansible/playbooks/seldon_core.yaml
+++ b/ansible/playbooks/seldon_core.yaml
@@ -19,7 +19,7 @@
     # Verify Install does not work with 1.7.x on k8s 1.18.x
     istio_verify_install: false
 
-    seldon_core_version: v1.8.0
+    seldon_core_version: v1.9.0
 
     seldon_core_values:
       istio:

--- a/tempo/seldon/runtime.py
+++ b/tempo/seldon/runtime.py
@@ -1,0 +1,6 @@
+from tempo.serve.metadata import RuntimeOptions
+
+
+class SeldonCoreOptions(RuntimeOptions):
+    runtime: str = "tempo.seldon.SeldonKubernetesRuntime"
+    add_svc_orchestrator: bool = False

--- a/tempo/seldon/specs.py
+++ b/tempo/seldon/specs.py
@@ -3,6 +3,7 @@ import json
 from tempo.k8s.constants import TempoK8sDescriptionAnnotation, TempoK8sLabel, TempoK8sModelSpecAnnotation
 from tempo.kfserving.protocol import KFServingV1Protocol, KFServingV2Protocol
 from tempo.seldon.constants import MLSERVER_IMAGE
+from tempo.seldon.runtime import SeldonCoreOptions
 from tempo.serve.base import ModelSpec
 from tempo.serve.constants import ENV_TEMPO_RUNTIME_OPTIONS
 from tempo.serve.metadata import ModelDetails, ModelFramework, RuntimeOptions
@@ -105,8 +106,10 @@ class KubernetesSpec:
     def __init__(
         self,
         model_details: ModelSpec,
+        runtime_options: SeldonCoreOptions,
     ):
         self._details = model_details
+        self._runtime_options = runtime_options
 
     @property
     def spec(self) -> dict:
@@ -160,6 +163,11 @@ class KubernetesSpec:
             "name": "default",
             "replicas": self._details.runtime_options.k8s_options.replicas,
         }
+
+        if not self._runtime_options.add_svc_orchestrator:
+            predictor["annotations"] = {
+                "seldon.io/no-engine": "true",
+            }
 
         if (
             self._details.model_details.platform == ModelFramework.TempoPipeline

--- a/tempo/serve/base.py
+++ b/tempo/serve/base.py
@@ -215,7 +215,7 @@ class BaseModel:
             cls_path = model_spec.runtime_options.docker_options.runtime
         logger.debug("Using remote class %s", cls_path)
         cls: Any = locate(cls_path)
-        return cls()
+        return cls(model_spec.runtime_options)
 
     def get_insights_mode(self) -> InsightRequestModes:
         return self.model_spec.runtime_options.insights_options.mode_type

--- a/tests/seldon/test_specs.py
+++ b/tests/seldon/test_specs.py
@@ -14,9 +14,7 @@ def test_kubernetes_spec(sklearn_model):
             "protocol": "seldon",
             "predictors": [
                 {
-                    "annotations" : {
-                        "seldon.io/no-engine": "true"
-                    },
+                    "annotations": {"seldon.io/no-engine": "true"},
                     "graph": {
                         "modelUri": sklearn_model.details.uri,
                         "name": "test-iris-sklearn",

--- a/tests/seldon/test_specs.py
+++ b/tests/seldon/test_specs.py
@@ -1,17 +1,22 @@
 from tempo.seldon.protocol import SeldonProtocol
+from tempo.seldon.runtime import SeldonCoreOptions
 from tempo.seldon.specs import KubernetesSpec, get_container_spec
 from tempo.serve.base import ModelSpec
 from tempo.serve.metadata import KubernetesOptions, ModelDataArgs, ModelDetails, ModelFramework, RuntimeOptions
 
 
 def test_kubernetes_spec(sklearn_model):
-    k8s_object = KubernetesSpec(sklearn_model.model_spec)
+
+    k8s_object = KubernetesSpec(sklearn_model.model_spec, SeldonCoreOptions())
 
     expected = {
         "spec": {
             "protocol": "seldon",
             "predictors": [
                 {
+                    "annotations" : {
+                        "seldon.io/no-engine": "true"
+                    },
                     "graph": {
                         "modelUri": sklearn_model.details.uri,
                         "name": "test-iris-sklearn",

--- a/tests/serve/test_yaml.py
+++ b/tests/serve/test_yaml.py
@@ -2,6 +2,7 @@ import pytest
 import yaml
 
 from tempo.seldon.k8s import SeldonKubernetesRuntime
+from tempo.seldon.runtime import SeldonCoreOptions
 from tempo.seldon.protocol import SeldonProtocol
 from tempo.serve.metadata import KubernetesOptions, ModelFramework, RuntimeOptions
 from tempo.serve.model import Model
@@ -21,7 +22,9 @@ metadata:
   namespace: default
 spec:
   predictors:
-  - graph:
+  - annotations:
+      seldon.io/no-engine: 'true'
+    graph:
       implementation: SKLEARN_SERVER
       modelUri: gs://seldon-models/sklearn/iris
       name: test-iris-sklearn
@@ -62,7 +65,9 @@ metadata:
   namespace: default
 spec:
   predictors:
-  - graph:
+  - annotations:
+      seldon.io/no-engine: 'true'
+    graph:
       implementation: XGBOOST_SERVER
       modelUri: gs://seldon-models/xgboost/iris
       name: test-iris-xgboost
@@ -103,7 +108,9 @@ metadata:
   namespace: default
 spec:
   predictors:
-  - graph:
+  - annotations:
+      seldon.io/no-engine: 'true'
+    graph:
       envSecretRefName: auth
       implementation: XGBOOST_SERVER
       modelUri: gs://seldon-models/xgboost/iris
@@ -124,7 +131,7 @@ def test_seldon_model_yaml_auth(expected):
         local_folder="/tmp/model",
     )
     runtime = SeldonKubernetesRuntime(
-        runtime_options=RuntimeOptions(k8s_options=KubernetesOptions(authSecretName="auth"))
+        runtime_options=SeldonCoreOptions(k8s_options=KubernetesOptions(authSecretName="auth"))
     )
     yaml_str = runtime.manifest(m)
     yaml_obj = yaml.safe_load(yaml_str)

--- a/tests/serve/test_yaml.py
+++ b/tests/serve/test_yaml.py
@@ -2,9 +2,9 @@ import pytest
 import yaml
 
 from tempo.seldon.k8s import SeldonKubernetesRuntime
-from tempo.seldon.runtime import SeldonCoreOptions
 from tempo.seldon.protocol import SeldonProtocol
-from tempo.serve.metadata import KubernetesOptions, ModelFramework, RuntimeOptions
+from tempo.seldon.runtime import SeldonCoreOptions
+from tempo.serve.metadata import KubernetesOptions, ModelFramework
 from tempo.serve.model import Model
 
 


### PR DESCRIPTION
 * Remove executor by default for Seldon Core runtime
 * Update SeldonCoreOptions to have a variable to control this
 * Update Ansible Seldon Core to use 1.9.0