### PR TITLE
Update version badge to be dynamic linked to PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
-![GitHub](https://img.shields.io/badge/Version-0.1.0-green.svg)
-![GitHub](https://img.shields.io/badge/Python-3.5—3.8-blue.svg)
-![GitHub](https://img.shields.io/badge/License-Apache-black.svg)
+[![Version](https://badge.fury.io/py/mlops-tempo.svg)](https://badge.fury.io/py/mlops-tempo)
+![Python version](https://img.shields.io/badge/Python-3.5—3.8-blue.svg)
+![License](https://img.shields.io/badge/License-Apache-black.svg)
 
 # ⏳ Tempo: The MLOps Software Development Kit
 


### PR DESCRIPTION
Noticed that the version badge is static and hadn't been updated for 0.2.0. Replaced this with a dynamic badge that shows the latest version released on PyPI which will look like this (and link to the PyPI page of tempo):

[![Version](https://badge.fury.io/py/mlops-tempo.svg)](https://badge.fury.io/py/mlops-tempo)

I've also updated the alt texts for all badges.