### PR TITLE
clarify note on k8s ansible collection

### DIFF
--- a/docs/overview/quickstart.md
+++ b/docs/overview/quickstart.md
@@ -27,7 +27,7 @@ Install [Docker](https://www.docker.com/) to run with the Docker runtime.
 ## Kubernetes Runtime Prequisites
 
 We provide a set of Ansible playbooks to create reproducible Kubernetes clusters with Kind for the demos.
-These playbooks are published as part of [SeldonIO/ansible-tools](https://github.com/SeldonIO/ansible-tools) repository.
+These playbooks depend on Ansible roles that we publish in  [SeldonIO/ansible-k8s-collection](https://github.com/SeldonIO/ansible-k8s-collection) repository.
 
 To obtain required ansible tools:
 ```bash


### PR DESCRIPTION
Clarify note about and link to the [ansible-k8s-collection](https://github.com/SeldonIO/ansible-k8s-collection) repo.