### PR TITLE
Add installation instructions

### DIFF
--- a/docs/api/tempo.rst
+++ b/docs/api/tempo.rst
@@ -18,8 +18,8 @@ Subpackages
    tempo.ingress
    tempo.insights
    tempo.k8s
-   tempo.kfserving
    tempo.metaflow
+   tempo.protocols
    tempo.seldon
    tempo.serve
    tempo.state

--- a/docs/api/tempo.seldon.rst
+++ b/docs/api/tempo.seldon.rst
@@ -17,5 +17,4 @@ Submodules
    tempo.seldon.docker
    tempo.seldon.endpoint
    tempo.seldon.k8s
-   tempo.seldon.protocol
    tempo.seldon.specs

--- a/docs/overview/quickstart.md
+++ b/docs/overview/quickstart.md
@@ -1,6 +1,16 @@
 # Quickstart
 
-## Tempo Prequisites
+## Installation
+The latest Tempo release can be installed from [PyPI](https://pypi.org/project/mlops-tempo/):
+```
+pip install mlops-tempo
+```
+Alternatively, the development version can be installed:
+```
+pip install git+https://github.com/SeldonIO/tempo.git
+```
+
+## Tempo Prerequisites
 
 
  * [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/index.html)


### PR DESCRIPTION
This PR adds the missing installation instructions. This is particularly needed because the PyPI package name is `mlops-tempo` as `tempo` is taken and is a completely different package.

FYI when building the docs, the two `.rst` files under `docs/api` were flagged as changed, so I've included them into this PR. Let me know if these changes are expected and/or if these need to be split out into a different PR.